### PR TITLE
Caminho do DB atualizado

### DIFF
--- a/installdebian11zb6.sh
+++ b/installdebian11zb6.sh
@@ -87,7 +87,7 @@ flush privileges;
 exit
 EOF
 
-  zcat /usr/share/doc/zabbix-sql-scripts/mysql/server.sql.gz |mysql -uroot -p${MYSQL_PASSWD} zabbix;
+  zcat /usr/share/zabbix-sql-scripts/mysql/server.sql.gz |mysql -uroot -p${MYSQL_PASSWD} zabbix;
 
   sudo sed -e 's/# ListenPort=.*/ListenPort=10051/g' \
        -e "s/# DBPassword=.*/DBPassword=${ZABBIX_PASSWD}/g" \


### PR DESCRIPTION
Ao usar o comando SQL "show tables" no banco de dados "zabbix", ele está vazio. O script não está mais importando o banco de dados do Zabbix conforme esperado porque mudou o caminho, conforme disponível no manual de instalação: https://www.zabbix.com/documentation/6.0/en/manual/installation/install_from_packages/debian_ubuntu#importing-data

A seguinte mensagem de erro é exibida durante a instalação Web sem a devida importação das tabelas ao tentar se conectar ao banco de dados: Unable to determine current Zabbix database version: the table "dbversion" was not found.